### PR TITLE
Fix PIL compatibility and Zone.Identifier filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,71 @@
+# Data folders
+data/
+test_output/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyTorch
+*.pth
+*.pt
+*.pkl
+*.pickle
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Environment variables
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Windows Zone.Identifier files
+*:Zone.Identifier
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+*.tmp
+*.temp

--- a/dataloader.py
+++ b/dataloader.py
@@ -49,7 +49,7 @@ class lowlight_loader(data.Dataset):
 		
 		data_lowlight = Image.open(data_lowlight_path)
 		
-		data_lowlight = data_lowlight.resize((self.size,self.size), Image.ANTIALIAS)
+		data_lowlight = data_lowlight.resize((self.size,self.size), Image.LANCZOS)
 		data_lowlight = (np.asarray(data_lowlight)/255.0) 
 		data_lowlight = torch.from_numpy(data_lowlight).float()
 

--- a/test.py
+++ b/test.py
@@ -39,6 +39,12 @@ class Tester():
     def test(self):
         self.net.eval()
         file_list = glob.glob(os.path.join(args.input_dir, '*'))  # get all the images in all the folders
+        
+        # Filter out Zone.Identifier files and only keep actual image files
+        image_extensions = ('.jpg', '.jpeg', '.png', '.bmp', '.tiff', '.tif')
+        file_list = [f for f in file_list if f.lower().endswith(image_extensions) and not f.endswith(':Zone.Identifier')]
+        
+        print(f"Found {len(file_list)} image files to process")
         sum_time = 0
 
         for image in file_list:


### PR DESCRIPTION
- Replace deprecated Image.ANTIALIAS with Image.LANCZOS in dataloader.py
- Add file filtering in test.py to exclude Zone.Identifier files
- Add comprehensive .gitignore to exclude data folders and model weights